### PR TITLE
fix: workspace parameter should not be required

### DIFF
--- a/src/apic-extension/azext_apic_extension/commands.py
+++ b/src/apic-extension/azext_apic_extension/commands.py
@@ -14,10 +14,16 @@ from .custom import ExportSpecificationExtension
 from .custom import ExportMetadataSchemaExtension
 from .custom import CreateMetadataSchemaExtension
 from .custom import UpdateMetadataSchemaExtension
+from .custom import UpdateAPIExtension
+from .custom import UpdateAPIDefinitionExtension
+from .custom import UpdateAPIVersionExtension
+from .custom import UpdateAPIDeploymentExtension
+from .custom import UpdateEnvironmentExtension
 
 
 def load_command_table(self, _):  # pylint: disable=unused-argument
     with self.command_group('apic api definition') as g:
+        self.command_table['apic api definition update'] = UpdateAPIDefinitionExtension(loader=self)
         self.command_table['apic api definition import-specification'] = ImportSpecificationExtension(loader=self)
         self.command_table['apic api definition export-specification'] = ExportSpecificationExtension(loader=self)
     with self.command_group('apic metadata-schema') as g:
@@ -26,3 +32,11 @@ def load_command_table(self, _):  # pylint: disable=unused-argument
         self.command_table['apic metadata-schema export-metadata-schema'] = ExportMetadataSchemaExtension(loader=self)
     with self.command_group('apic api') as g:
         g.custom_command("register", "register_apic")
+    with self.command_group('apic api') as g:
+        self.command_table['apic api update'] = UpdateAPIExtension(loader=self)
+    with self.command_group('apic api version') as g:
+        self.command_table['apic api version update'] = UpdateAPIVersionExtension(loader=self)
+    with self.command_group('apic api deployment') as g:
+        self.command_table['apic api deployment update'] = UpdateAPIDeploymentExtension(loader=self)
+    with self.command_group('apic environment') as g:
+        self.command_table['apic environment update'] = UpdateEnvironmentExtension(loader=self)

--- a/src/apic-extension/azext_apic_extension/custom.py
+++ b/src/apic-extension/azext_apic_extension/custom.py
@@ -22,9 +22,54 @@ from .aaz.latest.apic.api.definition import ExportSpecification
 from .aaz.latest.apic.metadata_schema import Create
 from .aaz.latest.apic.metadata_schema import Update
 from .aaz.latest.apic.metadata_schema import ExportMetadataSchema
+from .aaz.latest.apic.api import Update as UpdateAPI
+from .aaz.latest.apic.api.definition import Update as UpdateAPIDefinition
+from .aaz.latest.apic.api.deployment import Update as UpdateAPIDeployment
+from .aaz.latest.apic.api.version import Update as UpdateAPIVersion
+from .aaz.latest.apic.environment import Update as UpdateEnvironment
 
 logger = get_logger(__name__)
 
+
+class UpdateAPIExtension(UpdateAPI):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.workspace_name._required = False
+        args_schema.workspace_name._default = "default"
+        return args_schema
+
+class UpdateAPIDefinitionExtension(UpdateAPIDefinition):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.workspace_name._required = False
+        args_schema.workspace_name._default = "default"
+        return args_schema
+    
+class UpdateAPIDeploymentExtension(UpdateAPIDeployment):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.workspace_name._required = False
+        args_schema.workspace_name._default = "default"
+        return args_schema
+    
+class UpdateAPIVersionExtension(UpdateAPIVersion):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.workspace_name._required = False
+        args_schema.workspace_name._default = "default"
+        return args_schema
+    
+class UpdateEnvironmentExtension(UpdateEnvironment):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.workspace_name._required = False
+        args_schema.workspace_name._default = "default"
+        return args_schema
 
 class ImportSpecificationExtension(ImportSpecification):
     @classmethod


### PR DESCRIPTION
1. make workspace parameter optional
2. set workspace parameter default value to `default`

This change impacts following commands:
apic api update
apic api version update
apic api definition update
apic api deployment update
apic environment update