### PR TITLE
feat: revert min cli version change

### DIFF
--- a/src/apic-extension/azext_apic_extension/azext_metadata.json
+++ b/src/apic-extension/azext_apic_extension/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.57.0"
+    "azext.minCliCoreVersion": "2.51.0"
 }


### PR DESCRIPTION
Revert min cli version change as previous PRs do not use features from newer CLI version. The version is changed because I use latest aaz-dev tool, which hardcoded the min CLI version to 2.57.
Will schedule discussions on our policy of min CLI version update based on inputs from Azure CLI team.