### PR TITLE
chore: update codeowner for apic-extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /src/subscription/ @wilcobmsft
 
-/src/apic-extension/ @arpishahmsft
+/src/apic-extension/ @arpishahmsft @blackchoey @adashen
 
 /src/alias/ @Juliehzl
 


### PR DESCRIPTION
Update codeowner for apic-extension, which is expected to be persisted in upstream repo.