### PR TITLE
build: add cicd pipeline

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,48 @@
+name: CD
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Setup development environment
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        python -m pip install -U pip
+        pip install azdev
+        azdev setup -r .
+        azdev extension add apic-extension
+
+    # Append commit hash to the version. E.g. 1.0.0b4+abc1234
+    - name: Generate and update version
+      run: |
+        python ./github/workflows/update_version.py
+
+    - name: Build binary
+      run: |
+        source .venv/bin/activate
+        azdev extension build apic-extension
+
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.repository.upload_url }}
+        asset_path: ./dist/*.whl
+        asset_content_type: application/octet-stream

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,6 +5,10 @@ on:
     types: [closed]
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,10 +43,8 @@ jobs:
         azdev extension build apic-extension
 
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/upload-artifact@v3
       with:
-        upload_url: ${{ github.event.repository.upload_url }}
-        asset_path: ./dist/*.whl
-        asset_content_type: application/octet-stream
+        name: release
+        path: |
+          ./dist/*.whl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Setup development environment
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        python -m pip install -U pip
+        pip install azdev
+        azdev setup -r .
+        azdev extension add apic-extension
+
+    - name: Run style check
+      run: |
+        source .venv/bin/activate
+        azdev style apic-extension
+
+    - name: Run linter
+      run: |
+        source .venv/bin/activate
+        azdev linter apic-extension
+
+    - name: Run tests
+      run: |
+        source .venv/bin/activate
+        azdev test apic-extension

--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -1,0 +1,27 @@
+import re
+import os
+
+# Open the file
+with open("src/apic-extension/setup.py", "r") as f:
+    content = f.read()
+
+# Find the version string
+version_match = re.search(r"VERSION = '(.*?)'", content)
+if version_match is None:
+    raise ValueError("Could not find version string in setup.py")
+
+# Extract the original version
+original_version = version_match.group(1)
+
+# Get the commit hash
+commit_hash = os.getenv("GITHUB_SHA", "daily")[:7]
+
+# Create the new version string
+new_version = original_version + "+" + commit_hash
+
+# Replace the old version string with the new one
+content_new = re.sub(r"VERSION = '(.*?)'", f"VERSION = '{new_version}'", content)
+
+# Write the updated content back to the file
+with open("src/apic-extension/setup.py", "w") as f:
+    f.write(content_new)


### PR DESCRIPTION
CI pipeline:
1. run `azdev style`, `azdev linter`, `azdev test` for pull requests and commits

CD pipeline:
1. Build and upload extension to GitHub releases after PR is merged
2. Support manually trigger the pipeline to generate a daily build