### PR TITLE
feat: use 03-01 API from spec repo

### DIFF
--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -71,6 +73,7 @@ class Create(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -324,7 +327,7 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -399,7 +402,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",
@@ -424,6 +427,7 @@ class Create(AAZCommand):
             properties.license = AAZObjectType()
             properties.lifecycle_stage = AAZStrType(
                 serialized_name="lifecycleStage",
+                flags={"read_only": True},
             )
             properties.summary = AAZStrType()
             properties.terms_of_service = AAZObjectType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_delete.py
@@ -51,6 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -64,6 +65,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Delete(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -71,6 +73,7 @@ class Head(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_list.py
@@ -53,6 +53,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -63,6 +64,7 @@ class List(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -184,7 +186,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -198,7 +200,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",
@@ -223,6 +225,7 @@ class List(AAZCommand):
             properties.license = AAZObjectType()
             properties.lifecycle_stage = AAZStrType(
                 serialized_name="lifecycleStage",
+                flags={"read_only": True},
             )
             properties.summary = AAZStrType()
             properties.terms_of_service = AAZObjectType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_show.py
@@ -50,6 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -63,6 +64,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class Show(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -193,7 +196,7 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",
@@ -218,6 +221,7 @@ class Show(AAZCommand):
             properties.license = AAZObjectType()
             properties.lifecycle_stage = AAZStrType(
                 serialized_name="lifecycleStage",
+                flags={"read_only": True},
             )
             properties.summary = AAZStrType()
             properties.terms_of_service = AAZObjectType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -65,6 +66,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -86,7 +89,7 @@ class Update(AAZCommand):
         _args_schema.contacts = AAZListArg(
             options=["--contacts"],
             arg_group="Properties",
-            help="The contact information for the API.",
+            help="The set of contacts",
             nullable=True,
         )
         _args_schema.custom_properties = AAZFreeFormDictArg(
@@ -94,7 +97,6 @@ class Update(AAZCommand):
             arg_group="Properties",
             help="The custom metadata defined for API catalog entities.",
             nullable=True,
-            blank={},
         )
         _args_schema.description = AAZStrArg(
             options=["--description"],
@@ -108,7 +110,7 @@ class Update(AAZCommand):
         _args_schema.external_documentation = AAZListArg(
             options=["--external-documentation"],
             arg_group="Properties",
-            help="Additional, external documentation for the API.",
+            help="The set of external documentation",
             nullable=True,
         )
         _args_schema.kind = AAZStrArg(
@@ -480,7 +482,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -564,7 +566,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         api_read.properties = AAZObjectType(
-            flags={"client_flatten": True},
+            flags={"required": True, "client_flatten": True},
         )
         api_read.system_data = AAZObjectType(
             serialized_name="systemData",
@@ -589,6 +591,7 @@ class _UpdateHelper:
         properties.license = AAZObjectType()
         properties.lifecycle_stage = AAZStrType(
             serialized_name="lifecycleStage",
+            flags={"read_only": True},
         )
         properties.summary = AAZStrType()
         properties.terms_of_service = AAZObjectType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -58,6 +59,7 @@ class Create(AAZCommand):
             help="The name of the API definition.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -79,6 +82,7 @@ class Create(AAZCommand):
             help="The name of the API version.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -89,6 +93,7 @@ class Create(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -220,7 +225,7 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -254,7 +259,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_delete.py
@@ -51,6 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -84,6 +87,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -95,6 +99,7 @@ class Delete(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_export_specification.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_export_specification.py
@@ -51,6 +51,7 @@ class ExportSpecification(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class ExportSpecification(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class ExportSpecification(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -84,6 +87,7 @@ class ExportSpecification(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -95,6 +99,7 @@ class ExportSpecification(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -57,6 +58,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -80,6 +83,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -91,6 +95,7 @@ class Head(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_import_specification.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_import_specification.py
@@ -54,6 +54,7 @@ class ImportSpecification(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -64,6 +65,7 @@ class ImportSpecification(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -77,6 +79,7 @@ class ImportSpecification(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -87,6 +90,7 @@ class ImportSpecification(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -98,6 +102,7 @@ class ImportSpecification(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_list.py
@@ -50,6 +50,7 @@ class List(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -62,6 +63,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -71,6 +73,7 @@ class List(AAZCommand):
             help="The name of the API version.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -81,6 +84,7 @@ class List(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -210,7 +214,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -224,7 +228,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_show.py
@@ -50,6 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -73,6 +75,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -83,6 +86,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -94,6 +98,7 @@ class Show(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -221,7 +226,7 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/definition/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -62,6 +63,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_4",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -85,6 +88,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -95,6 +99,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -112,7 +117,7 @@ class Update(AAZCommand):
         _args_schema.title = AAZStrArg(
             options=["--title"],
             arg_group="Properties",
-            help="API version title.",
+            help="API definition title.",
             fmt=AAZStrArgFormat(
                 max_length=50,
                 min_length=1,
@@ -371,7 +376,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -414,7 +419,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         api_definition_read.properties = AAZObjectType(
-            flags={"client_flatten": True},
+            flags={"required": True, "client_flatten": True},
         )
         api_definition_read.system_data = AAZObjectType(
             serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -58,6 +59,7 @@ class Create(AAZCommand):
             help="The name of the API deployment.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -80,6 +83,7 @@ class Create(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_delete.py
@@ -51,6 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -85,6 +88,7 @@ class Delete(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -57,6 +58,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -81,6 +84,7 @@ class Head(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_list.py
@@ -50,6 +50,7 @@ class List(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -62,6 +63,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -72,6 +74,7 @@ class List(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -197,7 +200,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_show.py
@@ -50,6 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -73,6 +75,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -84,6 +87,7 @@ class Show(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -62,6 +63,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -85,6 +88,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -98,12 +102,11 @@ class Update(AAZCommand):
             arg_group="Properties",
             help="The custom metadata defined for API catalog entities.",
             nullable=True,
-            blank={},
         )
         _args_schema.definition_id = AAZStrArg(
             options=["--definition-id"],
             arg_group="Properties",
-            help="Service-scoped definition resource ID.",
+            help="API center-scoped definition resource ID.",
             nullable=True,
         )
         _args_schema.description = AAZStrArg(
@@ -118,13 +121,13 @@ class Update(AAZCommand):
         _args_schema.environment_id = AAZStrArg(
             options=["--environment-id"],
             arg_group="Properties",
-            help="Service-scoped environment resource ID.",
+            help="API center-scoped environment resource ID.",
             nullable=True,
         )
         _args_schema.server = AAZObjectArg(
             options=["--server"],
             arg_group="Properties",
-            help="Server",
+            help="The deployment server",
             nullable=True,
         )
         _args_schema.state = AAZStrArg(
@@ -137,7 +140,7 @@ class Update(AAZCommand):
         _args_schema.title = AAZStrArg(
             options=["--title"],
             arg_group="Properties",
-            help="Title",
+            help="API deployment title",
             nullable=True,
             fmt=AAZStrArgFormat(
                 max_length=50,

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Create(AAZCommand):
             help="The name of the API version.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -80,6 +83,7 @@ class Create(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -209,7 +213,7 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -243,7 +247,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_delete.py
@@ -51,6 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -64,6 +65,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -85,6 +88,7 @@ class Delete(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -70,6 +72,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -81,6 +84,7 @@ class Head(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_list.py
@@ -50,6 +50,7 @@ class List(AAZCommand):
             help="The name of the API.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -62,6 +63,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -72,6 +74,7 @@ class List(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -197,7 +200,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -211,7 +214,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_show.py
@@ -50,6 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -63,6 +64,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -73,6 +75,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -84,6 +87,7 @@ class Show(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -207,7 +211,7 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/version/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -65,6 +66,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_3",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -85,6 +88,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -102,7 +106,7 @@ class Update(AAZCommand):
         _args_schema.title = AAZStrArg(
             options=["--title"],
             arg_group="Properties",
-            help="API version.",
+            help="API version title.",
             fmt=AAZStrArgFormat(
                 max_length=50,
                 min_length=1,
@@ -353,7 +357,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -396,7 +400,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         api_version_read.properties = AAZObjectType(
-            flags={"client_flatten": True},
+            flags={"required": True, "client_flatten": True},
         )
         api_version_read.system_data = AAZObjectType(
             serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the environment.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -71,6 +73,7 @@ class Create(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -100,6 +103,7 @@ class Create(AAZCommand):
         _args_schema.onboarding = AAZObjectArg(
             options=["--onboarding"],
             arg_group="Properties",
+            help="Environment onboarding information",
         )
         _args_schema.server = AAZObjectArg(
             options=["--server"],
@@ -120,6 +124,7 @@ class Create(AAZCommand):
         onboarding = cls._args_schema.onboarding
         onboarding.developer_portal_uri = AAZListArg(
             options=["developer-portal-uri"],
+            help="The location of the development portal",
         )
         onboarding.instructions = AAZStrArg(
             options=["instructions"],
@@ -132,6 +137,7 @@ class Create(AAZCommand):
         server = cls._args_schema.server
         server.management_portal_uri = AAZListArg(
             options=["management-portal-uri"],
+            help="The location of the management portal",
         )
         server.type = AAZStrArg(
             options=["type"],
@@ -241,7 +247,7 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -301,7 +307,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_delete.py
@@ -51,6 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -64,6 +65,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Delete(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -71,6 +73,7 @@ class Head(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_list.py
@@ -53,6 +53,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -63,6 +64,7 @@ class List(AAZCommand):
             required=True,
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -184,7 +186,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -198,7 +200,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_show.py
@@ -50,6 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -63,6 +64,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -74,6 +76,7 @@ class Show(AAZCommand):
             id_part="child_name_1",
             default="default",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -193,7 +196,7 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/environment/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_2",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -65,6 +66,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -75,6 +77,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -88,12 +91,11 @@ class Update(AAZCommand):
             arg_group="Properties",
             help="The custom metadata defined for API catalog entities.",
             nullable=True,
-            blank={},
         )
         _args_schema.description = AAZStrArg(
             options=["--description"],
             arg_group="Properties",
-            help="Description.",
+            help="The environment description.",
             nullable=True,
         )
         _args_schema.kind = AAZStrArg(
@@ -105,6 +107,7 @@ class Update(AAZCommand):
         _args_schema.onboarding = AAZObjectArg(
             options=["--onboarding"],
             arg_group="Properties",
+            help="Environment onboarding information",
             nullable=True,
         )
         _args_schema.server = AAZObjectArg(
@@ -126,6 +129,7 @@ class Update(AAZCommand):
         onboarding = cls._args_schema.onboarding
         onboarding.developer_portal_uri = AAZListArg(
             options=["developer-portal-uri"],
+            help="The location of the development portal",
             nullable=True,
         )
         onboarding.instructions = AAZStrArg(
@@ -142,6 +146,7 @@ class Update(AAZCommand):
         server = cls._args_schema.server
         server.management_portal_uri = AAZListArg(
             options=["management-portal-uri"],
+            help="The location of the management portal",
             nullable=True,
         )
         server.type = AAZStrArg(
@@ -392,7 +397,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -461,7 +466,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         environment_read.properties = AAZObjectType(
-            flags={"client_flatten": True},
+            flags={"required": True, "client_flatten": True},
         )
         environment_read.system_data = AAZObjectType(
             serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_create.py
@@ -49,6 +49,7 @@ class Create(AAZCommand):
             help="The name of the metadata schema.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,6 +62,7 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -72,6 +74,7 @@ class Create(AAZCommand):
         _args_schema.assigned_to = AAZListArg(
             options=["--assigned-to"],
             arg_group="Properties",
+            help="The assignees",
         )
         _args_schema.schema = AAZStrArg(
             options=["--schema"],
@@ -86,6 +89,7 @@ class Create(AAZCommand):
         _element = cls._args_schema.assigned_to.Element
         _element.deprecated = AAZBoolArg(
             options=["deprecated"],
+            help="Deprecated assignment",
         )
         _element.entity = AAZStrArg(
             options=["entity"],
@@ -94,6 +98,7 @@ class Create(AAZCommand):
         )
         _element.required = AAZBoolArg(
             options=["required"],
+            help="Required assignment",
         )
         return cls._args_schema
 
@@ -191,7 +196,7 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -235,7 +240,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_delete.py
@@ -54,6 +54,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -67,6 +68,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_export_metadata_schema.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_export_metadata_schema.py
@@ -60,6 +60,7 @@ class ExportMetadataSchema(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_head.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_head.py
@@ -47,6 +47,7 @@ class Head(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,6 +61,7 @@ class Head(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_list.py
@@ -53,6 +53,7 @@ class List(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -170,7 +171,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"read_only": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -184,7 +185,7 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_show.py
@@ -53,6 +53,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -66,6 +67,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -181,7 +183,7 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200.properties = AAZObjectType(
-                flags={"client_flatten": True},
+                flags={"required": True, "client_flatten": True},
             )
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/metadata_schema/_update.py
@@ -52,6 +52,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -65,6 +66,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
@@ -76,12 +78,13 @@ class Update(AAZCommand):
         _args_schema.assigned_to = AAZListArg(
             options=["--assigned-to"],
             arg_group="Properties",
+            help="The assignees",
             nullable=True,
         )
         _args_schema.schema = AAZStrArg(
             options=["--schema"],
             arg_group="Properties",
-            help="YAML schema defining the type.",
+            help="The schema defining the type.",
         )
 
         assigned_to = cls._args_schema.assigned_to
@@ -92,6 +95,7 @@ class Update(AAZCommand):
         _element = cls._args_schema.assigned_to.Element
         _element.deprecated = AAZBoolArg(
             options=["deprecated"],
+            help="Deprecated assignment",
             nullable=True,
         )
         _element.entity = AAZStrArg(
@@ -102,6 +106,7 @@ class Update(AAZCommand):
         )
         _element.required = AAZBoolArg(
             options=["required"],
+            help="Required assignment",
             nullable=True,
         )
         return cls._args_schema
@@ -333,7 +338,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
+            _builder.set_prop("properties", AAZObjectType, ".", typ_kwargs={"flags": {"required": True, "client_flatten": True}})
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -386,7 +391,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         metadata_schema_read.properties = AAZObjectType(
-            flags={"client_flatten": True},
+            flags={"required": True, "client_flatten": True},
         )
         metadata_schema_read.system_data = AAZObjectType(
             serialized_name="systemData",

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_create.py
@@ -55,21 +55,22 @@ class Create(AAZCommand):
             help="The name of the API Center service.",
             required=True,
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
         )
 
-        # define Arg Group "Payload"
+        # define Arg Group "Resource"
 
         _args_schema = cls._args_schema
         _args_schema.identity = AAZObjectArg(
             options=["--identity"],
-            arg_group="Payload",
-            help="Managed service identity (system assigned and/or user assigned identities)",
+            arg_group="Resource",
+            help="The managed service identities assigned to this resource.",
         )
         _args_schema.location = AAZResourceLocationArg(
-            arg_group="Payload",
+            arg_group="Resource",
             help="The geo-location where the resource lives",
             required=True,
             fmt=AAZResourceLocationArgFormat(
@@ -78,7 +79,7 @@ class Create(AAZCommand):
         )
         _args_schema.tags = AAZDictArg(
             options=["--tags"],
-            arg_group="Payload",
+            arg_group="Resource",
             help="Resource tags.",
         )
 
@@ -192,7 +193,7 @@ class Create(AAZCommand):
             _content_value, _builder = self.new_content_builder(
                 self.ctx.args,
                 typ=AAZObjectType,
-                typ_kwargs={"flags": {"client_flatten": True}}
+                typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
             _builder.set_prop("identity", AAZObjectType, ".identity")
             _builder.set_prop("location", AAZStrType, ".location", typ_kwargs={"flags": {"required": True}})

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_delete.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_delete.py
@@ -54,6 +54,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_list.py
@@ -151,9 +151,10 @@ class List(AAZCommand):
             _schema_on_200 = cls._schema_on_200
             _schema_on_200.next_link = AAZStrType(
                 serialized_name="nextLink",
+                flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"required": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value
@@ -323,9 +324,10 @@ class List(AAZCommand):
             _schema_on_200 = cls._schema_on_200
             _schema_on_200.next_link = AAZStrType(
                 serialized_name="nextLink",
+                flags={"read_only": True},
             )
             _schema_on_200.value = AAZListType(
-                flags={"required": True},
+                flags={"required": True, "read_only": True},
             )
 
             value = cls._schema_on_200.value

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_show.py
@@ -53,6 +53,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/service/_update.py
@@ -55,23 +55,24 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
+                pattern="^[a-zA-Z0-9-]{3,90}$",
                 max_length=90,
                 min_length=1,
             ),
         )
 
-        # define Arg Group "Payload"
+        # define Arg Group "Resource"
 
         _args_schema = cls._args_schema
         _args_schema.identity = AAZObjectArg(
             options=["--identity"],
-            arg_group="Payload",
-            help="Managed service identity (system assigned and/or user assigned identities)",
+            arg_group="Resource",
+            help="The managed service identities assigned to this resource.",
             nullable=True,
         )
         _args_schema.tags = AAZDictArg(
             options=["--tags"],
-            arg_group="Payload",
+            arg_group="Resource",
             help="Resource tags.",
             nullable=True,
         )


### PR DESCRIPTION
1. Use 03-01 API from spec repo to regenerate all the CLI code: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/apicenter/resource-manager/Microsoft.ApiCenter/stable/2024-03-01/apicenter.json
2. The import from APIM command is out of this PR's scope as it's not in the spec
3. I made some changes to the API spec to work around bugs from typespec: https://github.com/blackchoey/azure-rest-api-specs/pull/1/files