### PR TITLE
feat!: remove file name param

### DIFF
--- a/src/apic-extension/azext_apic_extension/commands.py
+++ b/src/apic-extension/azext_apic_extension/commands.py
@@ -12,8 +12,6 @@
 from .custom import ImportSpecificationExtension
 from .custom import ExportSpecificationExtension
 from .custom import ExportMetadataSchemaExtension
-from .custom import CreateMetadataSchemaExtension
-from .custom import UpdateMetadataSchemaExtension
 
 
 def load_custom_commands(self, _):  # pylint: disable=unused-argument
@@ -21,8 +19,6 @@ def load_custom_commands(self, _):  # pylint: disable=unused-argument
         self.command_table['apic api definition import-specification'] = ImportSpecificationExtension(loader=self)
         self.command_table['apic api definition export-specification'] = ExportSpecificationExtension(loader=self)
     with self.command_group('apic metadata') as g:
-        self.command_table['apic metadata create'] = CreateMetadataSchemaExtension(loader=self)
-        self.command_table['apic metadata update'] = UpdateMetadataSchemaExtension(loader=self)
         self.command_table['apic metadata export'] = ExportMetadataSchemaExtension(loader=self)
     with self.command_group('apic api') as g:
         g.custom_command("register", "register_apic", is_preview=True)

--- a/src/apic-extension/azext_apic_extension/custom.py
+++ b/src/apic-extension/azext_apic_extension/custom.py
@@ -90,6 +90,7 @@ class ExportSpecificationExtension(ExportAPIDefinitionExtension):
                 else:
                     f.write(results)
 
+
 class ExportMetadataSchemaExtension(ExportMetadataExtension):
 
     @classmethod

--- a/src/apic-extension/azext_apic_extension/custom.py
+++ b/src/apic-extension/azext_apic_extension/custom.py
@@ -20,58 +20,15 @@ import chardet
 from azure.cli.core.aaz._arg import AAZStrArg
 from .command_patches import ImportAPIDefinitionExtension
 from .command_patches import ExportAPIDefinitionExtension
-from .command_patches import CreateMetadataExtension
 from .command_patches import ExportMetadataExtension
-from .aaz.latest.apic.metadata import Update as UpdateMetadataSchema
 
 logger = get_logger(__name__)
 
 
 class ImportSpecificationExtension(ImportAPIDefinitionExtension):
-    @classmethod
-    def _build_arguments_schema(cls, *args, **kwargs):
-        args_schema = super()._build_arguments_schema(*args, **kwargs)
-        args_schema.source_profile = AAZStrArg(
-            options=["--file-name"],
-            help='Name of the file from where to import the spec from.',
-            required=False,
-            registered=True
-        )
-        return args_schema
-
     def pre_operations(self):
         super().pre_operations()
         args = self.ctx.args
-        data = None
-        value = None
-
-        # Load the JSON file
-        if args.source_profile:
-            with open(str(args.source_profile), 'rb') as f:
-                data = f.read()
-                result = chardet.detect(data)
-                encoding = result['encoding']
-
-            if str(args.source_profile).endswith('.yaml') or str(args.source_profile).endswith('.yml'):
-                with open(str(args.source_profile), 'r', encoding=encoding) as f:
-                    content = f.read()
-                    data = yaml.safe_load(content)
-                    if data:
-                        value = content
-
-            if (str(args.source_profile).endswith('.json')):
-                with open(str(args.source_profile), 'r', encoding=encoding) as f:
-                    content = f.read()
-                    data = json.loads(content)
-                    if data:
-                        value = content
-
-        # If any of the fields are None, get them from self.args
-        if value is None:
-            value = args.value
-
-        # Reassign the values to self.args
-        args.value = value
 
         # Check the size of 'value' if format is inline and raise error if value is greater than 3 mb
         if args.format == 'inline':
@@ -132,89 +89,6 @@ class ExportSpecificationExtension(ExportAPIDefinitionExtension):
                     json.dump(results, f, indent=4, separators=(',', ':'))
                 else:
                     f.write(results)
-
-
-class CreateMetadataSchemaExtension(CreateMetadataExtension):
-    @classmethod
-    def _build_arguments_schema(cls, *args, **kwargs):
-        args_schema = super()._build_arguments_schema(*args, **kwargs)
-        args_schema.source_profile = AAZStrArg(
-            options=["--file-name"],
-            help='Name of the file from that contains the metadata schema.',
-            required=False,
-            registered=True
-        )
-        return args_schema
-
-    def pre_operations(self):
-        args = self.ctx.args
-        data = None
-        value = args.schema
-
-        # Load the JSON file
-        if args.source_profile:
-            with open(str(args.source_profile), 'rb') as f:
-                data = f.read()
-                result = chardet.detect(data)
-                encoding = result['encoding']
-
-            if os.stat(str(args.source_profile)).st_size == 0:
-                raise ValueError('Metadtata schema file is empty. Please provide a valid metadata schema file.')
-
-            with open(str(args.source_profile), 'r', encoding=encoding) as f:
-                data = json.load(f)
-                if data:
-                    value = json.dumps(data)
-
-        # If any of the fields are None, get them from self.args
-        if value is None:
-            logger.error('Please provide the schema to create the metadata schema'
-                         'through --schema option or through --file-name option via a file.')
-
-        # Reassign the values to self.args
-        self.ctx.args.schema = value
-
-
-class UpdateMetadataSchemaExtension(UpdateMetadataSchema):
-    @classmethod
-    def _build_arguments_schema(cls, *args, **kwargs):
-        args_schema = super()._build_arguments_schema(*args, **kwargs)
-        args_schema.source_profile = AAZStrArg(
-            options=["--file-name"],
-            help='Name of the file from that contains the metadata schema.',
-            required=False,
-            registered=True
-        )
-        return args_schema
-
-    def pre_operations(self):
-        args = self.ctx.args
-        data = None
-        value = args.schema
-
-        # Load the JSON file
-        if args.source_profile:
-            with open(str(args.source_profile), 'rb') as f:
-                rawdata = f.read()
-                result = chardet.detect(rawdata)
-                encoding = result['encoding']
-
-            if os.stat(str(args.source_profile)).st_size == 0:
-                raise ValueError('Metadtata schema file is empty. Please provide a valid metadata schema file.')
-
-            with open(str(args.source_profile), 'r', encoding=encoding) as f:
-                data = json.load(f)
-                if data:
-                    value = json.dumps(data)
-
-        # If any of the fields are None, get them from self.args
-        if value is None:
-            logger.error('Please provide the schema to update the metadata schema '
-                         'through --schema option or through --file-name option via a file.')
-
-        # Reassign the values to self.args
-        self.ctx.args.schema = value
-
 
 class ExportMetadataSchemaExtension(ExportMetadataExtension):
 
@@ -435,7 +309,7 @@ def register_apic(cmd, api_location, resource_group, service_name, environment_n
                 'definition_id': extracted_definition_name,
                 'format': 'inline',
                 'specification': specification_details,  # TODO write the correct spec object
-                'source_profile': api_location
+                'value': value
             }
 
             importAPISpecificationResults = ImportSpecificationExtension(cli_ctx=cmd.cli_ctx)(command_args=api_specification_args)

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
@@ -10,7 +10,6 @@ import os
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 from .utils import ApicServicePreparer, ApicApiPreparer, ApicVersionPreparer, ApicDefinitionPreparer
 
-from knack.util import CLIError
 
 class VersionCommandsTests(ScenarioTest):
 

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
@@ -126,20 +126,3 @@ class VersionCommandsTests(ScenarioTest):
             assert exported_content == imported_content, "The exported content is not the same as the imported content."
         finally:
             os.remove(exported_file_path)
-
-    @ResourceGroupPreparer(name_prefix="clirg", location='eastus', random_name_length=32)
-    @ApicServicePreparer()
-    @ApicApiPreparer()
-    @ApicVersionPreparer()
-    @ApicDefinitionPreparer()
-    def test_definition_import_large_value(self):
-        self.kwargs.update({
-            'specification': '{"name":"openapi","version":"3.0.0"}',
-            'file_name': "test_definition_import_large_value.txt"
-        })
-
-        with open(self.kwargs['file_name'], 'w') as file:
-            file.write('a' * 4 * 1024 * 1024) # generate a 4MB file
-
-        with self.assertRaisesRegexp(CLIError, 'The size of "value" is greater than 3 MB. Please use --format "link" to import the specification from a URL for size greater than 3 mb.') as cm:
-            self.cmd('az apic api definition import-specification -g {rg} -s {s} --api-id {api} --version-id {v} --definition-id {d} --format "inline" --specification \'{specification}\' --value "@{file_name}"')

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
@@ -10,7 +10,6 @@ import os
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 from .utils import ApicServicePreparer, ApicApiPreparer, ApicVersionPreparer, ApicDefinitionPreparer
 
-
 class VersionCommandsTests(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix="clirg", location='eastus', random_name_length=32)


### PR DESCRIPTION
Remove `--file-name` parameter for `az apic api definition import-specification`, `az apic metadata create` and `az apic metadata update` command.
Users should use `@filename` syntax provided by Azure CLI to read parameter value from a file directly.

https://msazure.visualstudio.com/One/_workitems/edit/28069265