### PR TITLE
feat!: remove state param for deployment commands

### DIFF
--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_create.py
@@ -121,12 +121,6 @@ class Create(AAZCommand):
             arg_group="Properties",
             help="Server",
         )
-        _args_schema.state = AAZStrArg(
-            options=["--state"],
-            arg_group="Properties",
-            help="State of API deployment.",
-            enum={"active": "active", "inactive": "inactive"},
-        )
         _args_schema.title = AAZStrArg(
             options=["--title"],
             arg_group="Properties",
@@ -262,7 +256,6 @@ class Create(AAZCommand):
                 properties.set_prop("description", AAZStrType, ".description")
                 properties.set_prop("environmentId", AAZStrType, ".environment_id")
                 properties.set_prop("server", AAZObjectType, ".server")
-                properties.set_prop("state", AAZStrType, ".state")
                 properties.set_prop("title", AAZStrType, ".title")
 
             custom_properties = _builder.get(".properties.customProperties")

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_update.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/api/deployment/_update.py
@@ -131,13 +131,6 @@ class Update(AAZCommand):
             help="Server",
             nullable=True,
         )
-        _args_schema.state = AAZStrArg(
-            options=["--state"],
-            arg_group="Properties",
-            help="State of API deployment.",
-            nullable=True,
-            enum={"active": "active", "inactive": "inactive"},
-        )
         _args_schema.title = AAZStrArg(
             options=["--title"],
             arg_group="Properties",
@@ -417,7 +410,6 @@ class Update(AAZCommand):
                 properties.set_prop("description", AAZStrType, ".description")
                 properties.set_prop("environmentId", AAZStrType, ".environment_id")
                 properties.set_prop("server", AAZObjectType, ".server")
-                properties.set_prop("state", AAZStrType, ".state")
                 properties.set_prop("title", AAZStrType, ".title")
 
             custom_properties = _builder.get(".properties.customProperties")

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_deployment_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_deployment_commands.py
@@ -41,7 +41,7 @@ class DeploymentCommandsTests(ScenarioTest):
           'server': '{"runtimeUri":["https://example.com"]}',
           'customProperties': '{{"{}":true}}'.format(metadata_name),
         })
-        self.cmd('az apic api deployment create -g {rg} -s {s} --api-id {api} --definition-id /workspaces/default/apis/{api}/versions/{v}/definitions/{d} --environment-id /workspaces/default/environments/{e} --deployment-id {name} --title "test deployment" --server \'{server}\' --description "deployment description" --state active --custom-properties \'{customProperties}\'', checks=[
+        self.cmd('az apic api deployment create -g {rg} -s {s} --api-id {api} --definition-id /workspaces/default/apis/{api}/versions/{v}/definitions/{d} --environment-id /workspaces/default/environments/{e} --deployment-id {name} --title "test deployment" --server \'{server}\' --description "deployment description" --custom-properties \'{customProperties}\'', checks=[
             self.check('name', '{name}'),
             self.check('title', 'test deployment'),
             self.check('server.runtimeUri[0]', 'https://example.com'),
@@ -49,8 +49,6 @@ class DeploymentCommandsTests(ScenarioTest):
             self.check('definitionId', '/workspaces/default/apis/{api}/versions/{v}/definitions/{d}'),
             self.check('environmentId', '/workspaces/default/environments/{e}'),
             self.check('description', 'deployment description'),
-            # TODO: Uncomment this line after Control Plane API fixed related bug
-            # self.check('state', 'active'),
         ])
 
     @ResourceGroupPreparer(name_prefix="clirg", location='eastus', random_name_length=32)
@@ -127,15 +125,13 @@ class DeploymentCommandsTests(ScenarioTest):
           'server': '{"runtimeUri":["https://example2.com"]}',
           'customProperties': '{{"{}":true}}'.format(metadata_name),
         })
-        self.cmd('az apic api deployment update -g {rg} -s {s} --api-id {api} --definition-id /workspaces/default/apis/{api}/versions/{v}/definitions/{d} --environment-id /workspaces/default/environments/{e} --deployment-id {dep} --title "updated deployment" --server \'{server}\' --description "deployment description" --state active --custom-properties \'{customProperties}\'', checks=[
+        self.cmd('az apic api deployment update -g {rg} -s {s} --api-id {api} --definition-id /workspaces/default/apis/{api}/versions/{v}/definitions/{d} --environment-id /workspaces/default/environments/{e} --deployment-id {dep} --title "updated deployment" --server \'{server}\' --description "deployment description" --custom-properties \'{customProperties}\'', checks=[
             self.check('title', 'updated deployment'),
             self.check('server.runtimeUri[0]', 'https://example2.com'),
             self.check('customProperties.{}'.format(metadata_name), True),
             self.check('definitionId', '/workspaces/default/apis/{api}/versions/{v}/definitions/{d}'),
             self.check('environmentId', '/workspaces/default/environments/{e}'),
             self.check('description', 'deployment description'),
-            # TODO: Uncomment this line after Control Plane API fixed related bug
-            # self.check('state', 'active'),
         ])
 
     @ResourceGroupPreparer(name_prefix="clirg", location='eastus', random_name_length=32)


### PR DESCRIPTION
Remove `--state` parameter for `az apic api deployment` commands because there's no user scenario for it.

https://msazure.visualstudio.com/One/_workitems/edit/28106452