### PR TITLE
fix: API title created by register command is not same with provided spec

### DIFF
--- a/src/apic-extension/azext_apic_extension/custom.py
+++ b/src/apic-extension/azext_apic_extension/custom.py
@@ -195,7 +195,7 @@ def register_apic(cmd, api_location, resource_group, service_name, environment_n
             extracted_api_name = _generate_api_id(info.get('title', 'Default-API')).lower()
             extracted_api_description = info.get('description', 'API Description')[:1000]
             extracted_api_summary = info.get('summary', str(extracted_api_description)[:200])
-            extracted_api_title = info.get('title', 'API Title').replace(" ", "-").lower()
+            extracted_api_title = info.get('title', 'API Title')
             extracted_api_version = info.get('version', 'v1').replace(".", "-").lower()
             extracted_api_version_title = info.get('version', 'v1').replace(".", "-").lower()
             # TODO -Create API Version lifecycle_stage

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_register_with_json_spec.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_register_with_json_spec.yaml
@@ -12,7 +12,8 @@ interactions:
       "kind": "rest", "license": {"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
       "summary": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You
       can find out more about\nSwagger at [http://swagger.io](http://swagger.io).
-      In the third iteration of the pet store, we''ve", "title": "swagger-petstore---openapi-3.0"}}'
+      In the third iteration of the pet store, we''ve", "title": "Swagger Petstore
+      - OpenAPI 3.0"}}'
     headers:
       Accept:
       - application/json
@@ -34,19 +35,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"swagger-petstore---openapi-3.0","summary":"This
-        is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You
-        can find out more about\nSwagger at [http://swagger.io](http://swagger.io).
-        In the third iteration of the pet store, we''ve","description":"This is a
-        sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find
-        out more about\nSwagger at [http://swagger.io](http://swagger.io). In the
-        third iteration of the pet store, we''ve switched to the design first approach!\nYou
-        can now help us improve the API whether it''s by making changes to the definition
-        itself or to the code.\nThat way, with time, we can improve the API in general,
-        and expose some of the new features in OAS3.\n\nSome useful links:\n- [The
-        Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"Swagger
+        Petstore - OpenAPI 3.0","summary":"This is a sample Pet Store Server based
+        on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at
+        [http://swagger.io](http://swagger.io). In the third iteration of the pet
+        store, we''ve","description":"This is a sample Pet Store Server based on the
+        OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io).
+        In the third iteration of the pet store, we''ve switched to the design first
+        approach!\nYou can now help us improve the API whether it''s by making changes
+        to the definition itself or to the code.\nThat way, with time, we can improve
+        the API in general, and expose some of the new features in OAS3.\n\nSome useful
+        links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
         [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)","kind":"rest","license":{"name":"Apache
-        2.0","url":"http://www.apache.org/licenses/LICENSE-2.0.html"},"externalDocumentation":[],"contacts":[{"email":"apiteam@swagger.io"}],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30","name":"swaggerpetstore-openapi30","systemData":{"createdAt":"2024-05-08T09:06:18.4695316Z","lastModifiedAt":"2024-05-08T09:06:18.4695303Z"}}'
+        2.0","url":"http://www.apache.org/licenses/LICENSE-2.0.html"},"externalDocumentation":[],"contacts":[{"email":"apiteam@swagger.io"}],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30","name":"swaggerpetstore-openapi30","systemData":{"createdAt":"2024-05-21T08:40:05.4281749Z","lastModifiedAt":"2024-05-21T08:40:05.4281734Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -57,9 +58,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:18 GMT
+      - Tue, 21 May 2024 08:40:05 GMT
       etag:
-      - d9036669-0000-0100-0000-663b408a0000
+      - 7a000511-0000-0100-0000-664c5de50000
       expires:
       - '-1'
       pragma:
@@ -75,7 +76,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 9D537846C08D4E178D95BFB0FFC8A3F9 Ref B: MAA201060514047 Ref C: 2024-05-08T09:06:16Z'
+      - 'Ref A: 31EC88B718064D179D0AA6A3D91CEB1A Ref B: MAA201060514029 Ref C: 2024-05-21T08:40:03Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -104,7 +105,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-19","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19","name":"1-0-19","systemData":{"createdAt":"2024-05-08T09:06:21.1301365Z","lastModifiedAt":"2024-05-08T09:06:21.1301349Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-19","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19","name":"1-0-19","systemData":{"createdAt":"2024-05-21T08:40:09.7949725Z","lastModifiedAt":"2024-05-21T08:40:09.7949717Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -115,9 +116,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:20 GMT
+      - Tue, 21 May 2024 08:40:09 GMT
       etag:
-      - a6050b02-0000-0100-0000-663b408d0000
+      - d70277b0-0000-0100-0000-664c5de90000
       expires:
       - '-1'
       pragma:
@@ -133,7 +134,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 6D53DC791F2B4F40B0989118898D106D Ref B: MAA201060513027 Ref C: 2024-05-08T09:06:19Z'
+      - 'Ref A: 410902CC8A6B4884A92591867DF3C3EF Ref B: MAA201060513021 Ref C: 2024-05-21T08:40:08Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -178,7 +179,7 @@ interactions:
         to the definition itself or to the code.\nThat way, with time, we can improve
         the API in general, and expose some of the new features in OAS3.\n\nSome useful
         links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
-        [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-08T09:06:24.0718796Z","lastModifiedAt":"2024-05-08T09:06:24.0718789Z"}}'
+        [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-21T08:40:14.3171419Z","lastModifiedAt":"2024-05-21T08:40:14.3171409Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -189,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:24 GMT
+      - Tue, 21 May 2024 08:40:13 GMT
       etag:
-      - 7e048b2a-0000-0100-0000-663b40900000
+      - cd002ef8-0000-0100-0000-664c5dee0000
       expires:
       - '-1'
       pragma:
@@ -207,7 +208,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: CC89692E462A4BDD807D743B37FE6514 Ref B: MAA201060514039 Ref C: 2024-05-08T09:06:22Z'
+      - 'Ref A: 5F1479CED8CD4FD8904D862EA34F2A43 Ref B: MAA201060516027 Ref C: 2024-05-21T08:40:12Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -659,7 +660,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 08 May 2024 09:06:26 GMT
+      - Tue, 21 May 2024 08:40:25 GMT
       expires:
       - '-1'
       pragma:
@@ -673,7 +674,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 6BF3FEEBF89F49F991EFB3CEA6D67CD2 Ref B: MAA201060514033 Ref C: 2024-05-08T09:06:25Z'
+      - 'Ref A: 11A12FCF4F364C2EAEB4AB14100C56AA Ref B: MAA201060515009 Ref C: 2024-05-21T08:40:23Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -698,19 +699,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"swagger-petstore---openapi-3.0","summary":"This
-        is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You
-        can find out more about\nSwagger at [http://swagger.io](http://swagger.io).
-        In the third iteration of the pet store, we''ve","description":"This is a
-        sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find
-        out more about\nSwagger at [http://swagger.io](http://swagger.io). In the
-        third iteration of the pet store, we''ve switched to the design first approach!\nYou
-        can now help us improve the API whether it''s by making changes to the definition
-        itself or to the code.\nThat way, with time, we can improve the API in general,
-        and expose some of the new features in OAS3.\n\nSome useful links:\n- [The
-        Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"Swagger
+        Petstore - OpenAPI 3.0","summary":"This is a sample Pet Store Server based
+        on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at
+        [http://swagger.io](http://swagger.io). In the third iteration of the pet
+        store, we''ve","description":"This is a sample Pet Store Server based on the
+        OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io).
+        In the third iteration of the pet store, we''ve switched to the design first
+        approach!\nYou can now help us improve the API whether it''s by making changes
+        to the definition itself or to the code.\nThat way, with time, we can improve
+        the API in general, and expose some of the new features in OAS3.\n\nSome useful
+        links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
         [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)","kind":"rest","lifecycleStage":"design","license":{"name":"Apache
-        2.0","url":"http://www.apache.org/licenses/LICENSE-2.0.html"},"externalDocumentation":[],"contacts":[{"email":"apiteam@swagger.io"}],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30","name":"swaggerpetstore-openapi30","systemData":{"createdAt":"2024-05-08T09:06:18.4695316Z","lastModifiedAt":"2024-05-08T09:06:18.4695303Z"}}'
+        2.0","url":"http://www.apache.org/licenses/LICENSE-2.0.html"},"externalDocumentation":[],"contacts":[{"email":"apiteam@swagger.io"}],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30","name":"swaggerpetstore-openapi30","systemData":{"createdAt":"2024-05-21T08:40:05.4281749Z","lastModifiedAt":"2024-05-21T08:40:05.4281734Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -721,9 +722,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:29 GMT
+      - Tue, 21 May 2024 08:40:29 GMT
       etag:
-      - d9038c69-0000-0100-0000-663b408d0000
+      - 7a002711-0000-0100-0000-664c5de90000
       expires:
       - '-1'
       pragma:
@@ -737,7 +738,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: FC386287292F4A44AE4ADA1BA7D50E66 Ref B: MAA201060515017 Ref C: 2024-05-08T09:06:28Z'
+      - 'Ref A: 63B6F3246770467782A3EB103AA411EB Ref B: MAA201060516027 Ref C: 2024-05-21T08:40:29Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -762,7 +763,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-19","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19","name":"1-0-19","systemData":{"createdAt":"2024-05-08T09:06:21.1301365Z","lastModifiedAt":"2024-05-08T09:06:21.1301349Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-19","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19","name":"1-0-19","systemData":{"createdAt":"2024-05-21T08:40:09.7949725Z","lastModifiedAt":"2024-05-21T08:40:09.7949717Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -773,9 +774,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:31 GMT
+      - Tue, 21 May 2024 08:40:32 GMT
       etag:
-      - a6050b02-0000-0100-0000-663b408d0000
+      - d70277b0-0000-0100-0000-664c5de90000
       expires:
       - '-1'
       pragma:
@@ -789,7 +790,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: F8BAF52F0CAB4D878F051DAC62FBB0CD Ref B: MAA201060516017 Ref C: 2024-05-08T09:06:30Z'
+      - 'Ref A: 35EC52E8EA524290AE9E769BE369757D Ref B: MAA201060515051 Ref C: 2024-05-21T08:40:32Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -822,7 +823,7 @@ interactions:
         to the definition itself or to the code.\nThat way, with time, we can improve
         the API in general, and expose some of the new features in OAS3.\n\nSome useful
         links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n-
-        [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)","specification":{"name":"openapi","version":"3-0-2"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-08T09:06:24.0718796Z","lastModifiedAt":"2024-05-08T09:06:27.1757838Z"}}'
+        [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)","specification":{"name":"openapi","version":"3-0-2"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore-openapi30/versions/1-0-19/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-21T08:40:14.3171419Z","lastModifiedAt":"2024-05-21T08:40:26.3223577Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -833,9 +834,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:33 GMT
+      - Tue, 21 May 2024 08:40:36 GMT
       etag:
-      - 7e04232b-0000-0100-0000-663b40930000
+      - cd0094f8-0000-0100-0000-664c5dfa0000
       expires:
       - '-1'
       pragma:
@@ -849,7 +850,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: E14722B8C2924505B65A82CDEBBED11F Ref B: MAA201060513029 Ref C: 2024-05-08T09:06:33Z'
+      - 'Ref A: D7D4EE21E8004FA7A15D5B4DFEBDC6DE Ref B: MAA201060514035 Ref C: 2024-05-21T08:40:35Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -1302,7 +1303,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 09:06:36 GMT
+      - Tue, 21 May 2024 08:40:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1318,7 +1319,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 46A9627CBBE6409E8F52AB91C2200402 Ref B: MAA201060515025 Ref C: 2024-05-08T09:06:35Z'
+      - 'Ref A: AB3B60598D52419B837FB9578B59542E Ref B: MAA201060515019 Ref C: 2024-05-21T08:40:37Z'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_register_with_yml_spec.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_register_with_yml_spec.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"properties": {"description": "API Description", "kind": "rest", "license":
-      {"name": "MIT"}, "summary": "API Description", "title": "swagger-petstore"}}'
+      {"name": "MIT"}, "summary": "API Description", "title": "Swagger Petstore"}}'
     headers:
       Accept:
       - application/json
@@ -23,8 +23,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"swagger-petstore","summary":"API
-        Description","description":"API Description","kind":"rest","license":{"name":"MIT"},"externalDocumentation":[],"contacts":[],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore","name":"swaggerpetstore","systemData":{"createdAt":"2024-05-08T08:35:22.4822929Z","lastModifiedAt":"2024-05-08T08:35:22.4822913Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"Swagger
+        Petstore","summary":"API Description","description":"API Description","kind":"rest","license":{"name":"MIT"},"externalDocumentation":[],"contacts":[],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore","name":"swaggerpetstore","systemData":{"createdAt":"2024-05-21T08:38:58.9478555Z","lastModifiedAt":"2024-05-21T08:38:58.9478543Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -35,9 +35,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:22 GMT
+      - Tue, 21 May 2024 08:38:59 GMT
       etag:
-      - d803d68a-0000-0100-0000-663b394a0000
+      - 7a009f0f-0000-0100-0000-664c5da20000
       expires:
       - '-1'
       pragma:
@@ -53,7 +53,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: A5184713B43B41888E592402C9F1F5E5 Ref B: MAA201060514039 Ref C: 2024-05-08T08:35:19Z'
+      - 'Ref A: 54902BED8E184788AEC3E27F72AB2F99 Ref B: MAA201060516037 Ref C: 2024-05-21T08:38:57Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -82,7 +82,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-0","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0","name":"1-0-0","systemData":{"createdAt":"2024-05-08T08:35:25.1954624Z","lastModifiedAt":"2024-05-08T08:35:25.1954618Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-0","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0","name":"1-0-0","systemData":{"createdAt":"2024-05-21T08:39:01.6015585Z","lastModifiedAt":"2024-05-21T08:39:01.6015578Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -93,9 +93,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:25 GMT
+      - Tue, 21 May 2024 08:39:01 GMT
       etag:
-      - a4055fe9-0000-0100-0000-663b394d0000
+      - d702c79c-0000-0100-0000-664c5da50000
       expires:
       - '-1'
       pragma:
@@ -111,7 +111,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 38EE63F977C842F9B2CC433FA0A67CBE Ref B: MAA201060514033 Ref C: 2024-05-08T08:35:23Z'
+      - 'Ref A: 142F96970CF64531AB6B0C501C1F14BB Ref B: MAA201060514035 Ref C: 2024-05-21T08:39:00Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -141,7 +141,7 @@ interactions:
   response:
     body:
       string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions/definitions","properties":{"title":"openapi","description":"API
-        Description"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-08T08:35:27.0111028Z","lastModifiedAt":"2024-05-08T08:35:27.0111019Z"}}'
+        Description"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-21T08:39:04.4846883Z","lastModifiedAt":"2024-05-21T08:39:04.4846853Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -152,9 +152,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:26 GMT
+      - Tue, 21 May 2024 08:39:04 GMT
       etag:
-      - 7c0482cd-0000-0100-0000-663b394f0000
+      - cd0010f6-0000-0100-0000-664c5da80000
       expires:
       - '-1'
       pragma:
@@ -168,9 +168,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-msedge-ref:
-      - 'Ref A: FF59188D7761451DAFA2E19AD8D64D10 Ref B: MAA201060513045 Ref C: 2024-05-08T08:35:26Z'
+      - 'Ref A: 0EEC59A9B3814C1D8BA2C68635189DB0 Ref B: MAA201060516029 Ref C: 2024-05-21T08:39:02Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -237,7 +237,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 08 May 2024 08:35:28 GMT
+      - Tue, 21 May 2024 08:39:07 GMT
       expires:
       - '-1'
       pragma:
@@ -251,7 +251,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: DEEF9600A5A64B2C94FAB4D927C1FA78 Ref B: MAA201060516009 Ref C: 2024-05-08T08:35:28Z'
+      - 'Ref A: 89169A115DA04E8BAF62F1A886CA5ACC Ref B: MAA201060516045 Ref C: 2024-05-21T08:39:05Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -276,8 +276,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"swagger-petstore","summary":"API
-        Description","description":"API Description","kind":"rest","lifecycleStage":"design","license":{"name":"MIT"},"externalDocumentation":[],"contacts":[],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore","name":"swaggerpetstore","systemData":{"createdAt":"2024-05-08T08:35:22.4822929Z","lastModifiedAt":"2024-05-08T08:35:22.4822913Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis","properties":{"title":"Swagger
+        Petstore","summary":"API Description","description":"API Description","kind":"rest","lifecycleStage":"design","license":{"name":"MIT"},"externalDocumentation":[],"contacts":[],"customProperties":{}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore","name":"swaggerpetstore","systemData":{"createdAt":"2024-05-21T08:38:58.9478555Z","lastModifiedAt":"2024-05-21T08:38:58.9478543Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -288,9 +288,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:31 GMT
+      - Tue, 21 May 2024 08:39:09 GMT
       etag:
-      - d803408b-0000-0100-0000-663b394d0000
+      - 7a00b80f-0000-0100-0000-664c5da50000
       expires:
       - '-1'
       pragma:
@@ -304,7 +304,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: 101436DD6C034CC2A8956DC41A7E123F Ref B: MAA201060513053 Ref C: 2024-05-08T08:35:31Z'
+      - 'Ref A: A979E0377F754840A02A6F0BF7F05005 Ref B: MAA201060516039 Ref C: 2024-05-21T08:39:08Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -329,7 +329,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-0","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0","name":"1-0-0","systemData":{"createdAt":"2024-05-08T08:35:25.1954624Z","lastModifiedAt":"2024-05-08T08:35:25.1954618Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions","properties":{"title":"1-0-0","lifecycleStage":"design"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0","name":"1-0-0","systemData":{"createdAt":"2024-05-21T08:39:01.6015585Z","lastModifiedAt":"2024-05-21T08:39:01.6015578Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -340,9 +340,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:34 GMT
+      - Tue, 21 May 2024 08:39:13 GMT
       etag:
-      - a4055fe9-0000-0100-0000-663b394d0000
+      - d702c79c-0000-0100-0000-664c5da50000
       expires:
       - '-1'
       pragma:
@@ -356,7 +356,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: 9CCC0A96BF65497983169F0423D11D84 Ref B: MAA201060513019 Ref C: 2024-05-08T08:35:33Z'
+      - 'Ref A: 56CBF27346004C3E91B3D9144BDFBBC1 Ref B: MAA201060515025 Ref C: 2024-05-21T08:39:12Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -382,7 +382,7 @@ interactions:
   response:
     body:
       string: '{"type":"Microsoft.ApiCenter/services/workspaces/apis/versions/definitions","properties":{"title":"openapi","description":"API
-        Description","specification":{"name":"openapi","version":"3-0-0"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-08T08:35:27.0111028Z","lastModifiedAt":"2024-05-08T08:35:29.4536367Z"}}'
+        Description","specification":{"name":"openapi","version":"3-0-0"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002/workspaces/default/apis/swaggerpetstore/versions/1-0-0/definitions/openapi","name":"openapi","systemData":{"createdAt":"2024-05-21T08:39:04.4846883Z","lastModifiedAt":"2024-05-21T08:39:07.4396415Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
@@ -393,9 +393,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:36 GMT
+      - Tue, 21 May 2024 08:39:15 GMT
       etag:
-      - 7c04d3cd-0000-0100-0000-663b39510000
+      - cd0029f6-0000-0100-0000-664c5dab0000
       expires:
       - '-1'
       pragma:
@@ -409,7 +409,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-msedge-ref:
-      - 'Ref A: 1F09B1B9D7E64116BC6E8A8A6E1682A4 Ref B: MAA201060514025 Ref C: 2024-05-08T08:35:36Z'
+      - 'Ref A: ED4A7C41A1C540FFBFFE68B0288A307A Ref B: MAA201060514009 Ref C: 2024-05-21T08:39:14Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -476,7 +476,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 May 2024 08:35:39 GMT
+      - Tue, 21 May 2024 08:39:17 GMT
       expires:
       - '-1'
       pragma:
@@ -492,7 +492,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-msedge-ref:
-      - 'Ref A: 46FA595442E442C4AC0F942CB4A63E00 Ref B: MAA201060513031 Ref C: 2024-05-08T08:35:38Z'
+      - 'Ref A: 8BBF0CFC666F4A80A574F20BEE38B120 Ref B: MAA201060515045 Ref C: 2024-05-21T08:39:16Z'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_register_command.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_register_command.py
@@ -32,7 +32,7 @@ class RegisterCommandTests(ScenarioTest):
             self.check('license.name', 'MIT'),
             self.check('lifecycleStage', 'design'), # default value assigned by APIC
             self.check('name', 'swaggerpetstore'),
-            self.check('title', 'swagger-petstore')
+            self.check('title', 'Swagger Petstore')
         ])
 
         self.cmd('az apic api version show -g {rg} -s {s} --api-id swaggerpetstore --version-id 1-0-0', checks=[
@@ -82,7 +82,7 @@ class RegisterCommandTests(ScenarioTest):
             self.check('lifecycleStage', 'design'),
             self.check('name', 'swaggerpetstore-openapi30'),
             self.check('summary', 'This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we\'ve'),
-            self.check('title', 'swagger-petstore---openapi-3.0'),
+            self.check('title', 'Swagger Petstore - OpenAPI 3.0'),
         ])
 
         self.cmd('az apic api version show -g {rg} -s {s} --api-id swaggerpetstore-openapi30 --version-id 1-0-19', checks=[


### PR DESCRIPTION
The API title of APIs created by `az apic api register` command is not the same with provided spec. Fix this issue.

https://msazure.visualstudio.com/One/_queries/edit/27998100/?triage=true