### PR TITLE
fix: some parameters should be required in import-specification and deployment command

### DIFF
--- a/src/apic-extension/HISTORY.rst
+++ b/src/apic-extension/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 
 1.0.0
-++++++
+++++++++++++++++++
 * Update: Redesigned `az apic service import-from-apim` command to provide easier way to specify APIM instance
 * Fix: API title created by register command is not same with provided spec
 * Fix: Error not thrown when import spec with >3MB file
@@ -15,7 +15,7 @@ Release History
 * Remove: `--file-name`` parameter for `az apic api definition import-specification`, `az apic metadata create` and `az apic metadata update` command. Use the `@filename` syntax provided by Azure CLI to read parameter value from a file directly.
 
 1.0.0b5
-++++++
+++++++++++++++++++
 * Add: Support yaml file for `az apic api register` command.
 * Update: Command names, parameter names, and command descriptions for better understanding. Please leverage `-h` option or refer Azure CLI reference doc to see full list of commands and parameters.
 * Update: Introduction to parameter constraints to ensure that valid values are provided.
@@ -26,17 +26,17 @@ Release History
 * Remove: `head` commands in each command group are removed.
 
 1.0.0b4
-++++++
+++++++++++++++++++
 * Add: Support for Default Portal configuration and default hostname provisoning deprovisioning commands
 
 1.0.0b3
-++++++
+++++++++++++++++++
 * Add: Support for Import from apim command along with add examples for create service
 
 1.0.0b2
-++++++
+++++++++++++++++++
 * Remove: All workspace cli commands as it should not be exposed to customers just yet.
 
 1.0.0b1
-++++++
+++++++++++++++++++
 * Initial release.

--- a/src/apic-extension/HISTORY.rst
+++ b/src/apic-extension/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 * Fix: API title created by register command is not same with provided spec
 * Fix: Error not thrown when import spec with >3MB file
 * Fix: Error when register API with long description in spec
+* Fix: `--definition-id`, `--environment-id`, `--server`, `--title` parameters should be required in `az apic api deployment create` command
+* Fix: `--format`, `--specification`, `--value` parameters should be required in `az apic api definition import-specification` command
 * Remove: `--state`` parameter for `az apic api deployment` commands.
 * Remove: `--file-name`` parameter for `az apic api definition import-specification`, `az apic metadata create` and `az apic metadata update` command. Use the `@filename` syntax provided by Azure CLI to read parameter value from a file directly.
 

--- a/src/apic-extension/HISTORY.rst
+++ b/src/apic-extension/HISTORY.rst
@@ -15,7 +15,7 @@ Release History
 * Remove: `--file-name`` parameter for `az apic api definition import-specification`, `az apic metadata create` and `az apic metadata update` command. Use the `@filename` syntax provided by Azure CLI to read parameter value from a file directly.
 
 1.0.0b5
-+++++
+++++++
 * Add: Support yaml file for `az apic api register` command.
 * Update: Command names, parameter names, and command descriptions for better understanding. Please leverage `-h` option or refer Azure CLI reference doc to see full list of commands and parameters.
 * Update: Introduction to parameter constraints to ensure that valid values are provided.
@@ -26,11 +26,11 @@ Release History
 * Remove: `head` commands in each command group are removed.
 
 1.0.0b4
-+++++
+++++++
 * Add: Support for Default Portal configuration and default hostname provisoning deprovisioning commands
 
 1.0.0b3
-+++++
+++++++
 * Add: Support for Import from apim command along with add examples for create service
 
 1.0.0b2

--- a/src/apic-extension/azext_apic_extension/command_patches.py
+++ b/src/apic-extension/azext_apic_extension/command_patches.py
@@ -101,7 +101,15 @@ class ExportAPIDefinitionExtension(DefaultWorkspaceParameter, ExportAPIDefinitio
 
 
 class ImportAPIDefinitionExtension(DefaultWorkspaceParameter, ImportAPIDefinition):
-    pass
+    # pylint: disable=too-few-public-methods
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        # pylint: disable=protected-access
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.format._required = True
+        args_schema.specification._required = True
+        args_schema.value._required = True
+        return args_schema
 
 
 class ListAPIDefinitionExtension(DefaultWorkspaceParameter, ListAPIDefinition):
@@ -139,7 +147,16 @@ class UpdateAPIVersionExtension(DefaultWorkspaceParameter, UpdateAPIVersion):
 
 # `az apic api deployment` commands
 class CreateAPIDeploymentExtension(DefaultWorkspaceParameter, CreateAPIDeployment):
-    pass
+    # pylint: disable=too-few-public-methods
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        # pylint: disable=protected-access
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.definition_id._required = True
+        args_schema.environment_id._required = True
+        args_schema.server._required = True
+        args_schema.title._required = True
+        return args_schema
 
 
 class DeleteAPIDeploymentExtension(DefaultWorkspaceParameter, DeleteAPIDeployment):


### PR DESCRIPTION
* `--definition-id`, `--environment-id`, `--server`, `--title` parameters should be required in `az apic api deployment create` command
* `--format`, `--specification`, `--value` parameters should be required in `az apic api definition import-specification` command


https://msazure.visualstudio.com/One/_workitems/edit/28011693
https://msazure.visualstudio.com/One/_workitems/edit/28042590