### PR TITLE
fix: cannot run create command against existing resource

### DIFF
--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/_create.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/_create.py
@@ -96,6 +96,16 @@ class Create(AAZCommand):
 
         tags = cls._args_schema.tags
         tags.Element = AAZStrArg()
+
+        # define Arg Group "Sku"
+
+        _args_schema = cls._args_schema
+        _args_schema.sku_name = AAZStrArg(
+            options=["--sku-name"],
+            arg_group="Sku",
+            help="The name of the SKU. E.g. P3. It is typically a letter+number code",
+            default="Free",
+        )
         return cls._args_schema
 
     def _execute_operations(self):
@@ -190,6 +200,7 @@ class Create(AAZCommand):
             )
             _builder.set_prop("identity", AAZObjectType, ".identity")
             _builder.set_prop("location", AAZStrType, ".location", typ_kwargs={"flags": {"required": True}})
+            _builder.set_prop("sku", AAZObjectType)
             _builder.set_prop("tags", AAZDictType, ".tags")
 
             identity = _builder.get(".identity")
@@ -200,6 +211,10 @@ class Create(AAZCommand):
             user_assigned_identities = _builder.get(".identity.userAssignedIdentities")
             if user_assigned_identities is not None:
                 user_assigned_identities.set_elements(AAZObjectType, ".", typ_kwargs={"nullable": True})
+
+            sku = _builder.get(".sku")
+            if sku is not None:
+                sku.set_prop("name", AAZStrType, ".sku_name", typ_kwargs={"flags": {"required": True}})
 
             tags = _builder.get(".tags")
             if tags is not None:
@@ -238,6 +253,7 @@ class Create(AAZCommand):
             _schema_on_200_201.properties = AAZObjectType(
                 flags={"client_flatten": True},
             )
+            _schema_on_200_201.sku = AAZObjectType()
             _schema_on_200_201.system_data = AAZObjectType(
                 serialized_name="systemData",
                 flags={"read_only": True},
@@ -287,6 +303,15 @@ class Create(AAZCommand):
                 serialized_name="provisioningState",
                 flags={"read_only": True},
             )
+
+            sku = cls._schema_on_200_201.sku
+            sku.capacity = AAZIntType()
+            sku.family = AAZStrType()
+            sku.name = AAZStrType(
+                flags={"required": True},
+            )
+            sku.size = AAZStrType()
+            sku.tier = AAZStrType()
 
             system_data = cls._schema_on_200_201.system_data
             system_data.created_at = AAZStrType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/_list.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/_list.py
@@ -176,6 +176,7 @@ class List(AAZCommand):
             _element.properties = AAZObjectType(
                 flags={"client_flatten": True},
             )
+            _element.sku = AAZObjectType()
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",
                 flags={"read_only": True},
@@ -225,6 +226,15 @@ class List(AAZCommand):
                 serialized_name="provisioningState",
                 flags={"read_only": True},
             )
+
+            sku = cls._schema_on_200.value.Element.sku
+            sku.capacity = AAZIntType()
+            sku.family = AAZStrType()
+            sku.name = AAZStrType(
+                flags={"required": True},
+            )
+            sku.size = AAZStrType()
+            sku.tier = AAZStrType()
 
             system_data = cls._schema_on_200.value.Element.system_data
             system_data.created_at = AAZStrType(
@@ -349,6 +359,7 @@ class List(AAZCommand):
             _element.properties = AAZObjectType(
                 flags={"client_flatten": True},
             )
+            _element.sku = AAZObjectType()
             _element.system_data = AAZObjectType(
                 serialized_name="systemData",
                 flags={"read_only": True},
@@ -398,6 +409,15 @@ class List(AAZCommand):
                 serialized_name="provisioningState",
                 flags={"read_only": True},
             )
+
+            sku = cls._schema_on_200.value.Element.sku
+            sku.capacity = AAZIntType()
+            sku.family = AAZStrType()
+            sku.name = AAZStrType(
+                flags={"required": True},
+            )
+            sku.size = AAZStrType()
+            sku.tier = AAZStrType()
 
             system_data = cls._schema_on_200.value.Element.system_data
             system_data.created_at = AAZStrType(

--- a/src/apic-extension/azext_apic_extension/aaz/latest/apic/_show.py
+++ b/src/apic-extension/azext_apic_extension/aaz/latest/apic/_show.py
@@ -171,6 +171,7 @@ class Show(AAZCommand):
             _schema_on_200.properties = AAZObjectType(
                 flags={"client_flatten": True},
             )
+            _schema_on_200.sku = AAZObjectType()
             _schema_on_200.system_data = AAZObjectType(
                 serialized_name="systemData",
                 flags={"read_only": True},
@@ -220,6 +221,15 @@ class Show(AAZCommand):
                 serialized_name="provisioningState",
                 flags={"read_only": True},
             )
+
+            sku = cls._schema_on_200.sku
+            sku.capacity = AAZIntType()
+            sku.family = AAZStrType()
+            sku.name = AAZStrType(
+                flags={"required": True},
+            )
+            sku.size = AAZStrType()
+            sku.tier = AAZStrType()
 
             system_data = cls._schema_on_200.system_data
             system_data.created_at = AAZStrType(

--- a/src/apic-extension/azext_apic_extension/command_patches.py
+++ b/src/apic-extension/azext_apic_extension/command_patches.py
@@ -46,7 +46,7 @@ from .aaz.latest.apic.metadata import (
     Create as CreateMetadata,
     Export as ExportMetadata
 )
-from .aaz.latest.apic import ImportFromApim
+from .aaz.latest.apic import ImportFromApim, Create as CreateService
 
 from azure.cli.core.aaz._arg import AAZStrArg, AAZListArg
 
@@ -65,6 +65,21 @@ class DefaultWorkspaceParameter:
         args = self.ctx.args
         args.workspace_name = "default"
 
+
+# `az apic` commands
+class CreateServiceExtension(CreateService):
+    # pylint: disable=too-few-public-methods
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        # pylint: disable=protected-access
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        # temporary hide sku parameter as SKU has many fields and we needs more discussion on the UX
+        args_schema.sku_name._registered = False
+        return args_schema
+    
+    def pre_operations(self):
+        args = self.ctx.args
+        args.sku_name = "Free"
 
 # `az apic api` commands
 class CreateAPIExtension(DefaultWorkspaceParameter, CreateAPI):

--- a/src/apic-extension/azext_apic_extension/command_patches.py
+++ b/src/apic-extension/azext_apic_extension/command_patches.py
@@ -76,10 +76,11 @@ class CreateServiceExtension(CreateService):
         # temporary hide sku parameter as SKU has many fields and we needs more discussion on the UX
         args_schema.sku_name._registered = False
         return args_schema
-    
+
     def pre_operations(self):
         args = self.ctx.args
         args.sku_name = "Free"
+
 
 # `az apic api` commands
 class CreateAPIExtension(DefaultWorkspaceParameter, CreateAPI):

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_create_service_multiple_times.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_create_service_multiple_times.yaml
@@ -1,0 +1,210 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clirg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001","name":"clirg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_create_service_multiple_times","date":"2024-06-24T07:37:39Z","module":"apic-extension"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:37:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: CA1D7A3DBF494AB5B1FC58224A768782 Ref B: MAA201060513047 Ref C: 2024-06-24T07:37:45Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "sku": {"name": "Free"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '47'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/cli000002?api-version=2024-03-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/cli000002","name":"cli000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:37:50.3623836Z","lastModifiedAt":"2024-06-24T07:37:50.3623763Z"}}'
+    headers:
+      api-supported-versions:
+      - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:37:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 5D5AC4C2C12343A9B45DB46CA0E0FE83 Ref B: MAA201060514037 Ref C: 2024-06-24T07:37:46Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clirg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001","name":"clirg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_create_service_multiple_times","date":"2024-06-24T07:37:39Z","module":"apic-extension"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:37:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: 7D79E9FD6F9C4AAAB57B552F6B721594 Ref B: MAA201060513033 Ref C: 2024-06-24T07:37:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "sku": {"name": "Free"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '47'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/cli000002?api-version=2024-03-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{"dataApiHostname":"cli000002.data.eastus.azure-apicenter.ms"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/cli000002","name":"cli000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:37:50.3623836Z","lastModifiedAt":"2024-06-24T07:37:54.5120051Z"}}'
+    headers:
+      api-supported-versions:
+      - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:37:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 2475553047E045ADA6F5F2DA9000FAB5 Ref B: MAA201060515045 Ref C: 2024-06-24T07:37:53Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_examples_update_service_details.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_examples_update_service_details.yaml
@@ -1,6 +1,61 @@
 interactions:
 - request:
-    body: '{}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:41:10.8479478Z","lastModifiedAt":"2024-06-24T07:41:10.8479401Z"}}'
+    headers:
+      api-supported-versions:
+      - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '375'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:41:13 GMT
+      etag:
+      - 1a00fba9-0000-0100-0000-667923180000
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: E1B5EFEBCBF949AEABCBBA2C75F2C15D Ref B: MAA201060513029 Ref C: 2024-06-24T07:41:13Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {}, "sku": {"name": "Free"}, "tags":
+      {}}'
     headers:
       Accept:
       - application/json
@@ -11,31 +66,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2'
+      - '77'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n
       User-Agent:
       - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
-    method: PATCH
+    method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","identity":{"type":"None"},"sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{},"systemData":{"createdAt":"2024-06-17T06:13:03.4042175Z","lastModifiedAt":"2024-06-17T06:13:06.4414849Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{"dataApiHostname":"clitest000002.data.eastus.azure-apicenter.ms"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:41:10.8479478Z","lastModifiedAt":"2024-06-24T07:41:15.5003845Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
       cache-control:
       - no-cache
       content-length:
-      - '402'
+      - '439'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Jun 2024 06:13:06 GMT
-      etag:
-      - bb015c75-0000-0100-0000-666fd3f20000
+      - Mon, 24 Jun 2024 07:41:14 GMT
       expires:
       - '-1'
       pragma:
@@ -53,7 +106,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '199'
       x-msedge-ref:
-      - 'Ref A: 88223ADB886A41DFB7994147777C52A9 Ref B: MAA201060515029 Ref C: 2024-06-17T06:13:05Z'
+      - 'Ref A: 43C6D292DD9F43F2A006A9D01E4DD4E5 Ref B: MAA201060513029 Ref C: 2024-06-24T07:41:14Z'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_update_service.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_update_service.yaml
@@ -1,6 +1,61 @@
 interactions:
 - request:
-    body: '{"tags": {"test": "value"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --tags
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:41:17.4551506Z","lastModifiedAt":"2024-06-24T07:41:17.4551422Z"}}'
+    headers:
+      api-supported-versions:
+      - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '375'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:41:19 GMT
+      etag:
+      - 1a0001aa-0000-0100-0000-6679231d0000
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: FE306FF527424F5B8D768270F03A2F05 Ref B: MAA201060516031 Ref C: 2024-06-24T07:41:19Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {}, "sku": {"name": "Free"}, "tags":
+      {"test": "value"}}'
     headers:
       Accept:
       - application/json
@@ -11,31 +66,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '27'
+      - '92'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --tags
       User-Agent:
       - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
-    method: PATCH
+    method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","identity":{"type":"None"},"sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{"test":"value"},"systemData":{"createdAt":"2024-06-17T06:13:30.9632558Z","lastModifiedAt":"2024-06-17T06:13:34.5924106Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{"dataApiHostname":"clitest000002.data.eastus.azure-apicenter.ms"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{"test":"value"},"systemData":{"createdAt":"2024-06-24T07:41:17.4551506Z","lastModifiedAt":"2024-06-24T07:41:23.490113Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
       cache-control:
       - no-cache
       content-length:
-      - '416'
+      - '452'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Jun 2024 06:13:36 GMT
-      etag:
-      - bb01b079-0000-0100-0000-666fd40e0000
+      - Mon, 24 Jun 2024 07:41:25 GMT
       expires:
       - '-1'
       pragma:
@@ -53,7 +106,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '199'
       x-msedge-ref:
-      - 'Ref A: 9BA2DD794A844002848904B409154CA6 Ref B: MAA201060513035 Ref C: 2024-06-17T06:13:33Z'
+      - 'Ref A: 232B150B725448CCAAA5128DB231487F Ref B: MAA201060516031 Ref C: 2024-06-24T07:41:20Z'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_update_service_with_all_optional_params.yaml
+++ b/src/apic-extension/azext_apic_extension/tests/latest/recordings/test_update_service_with_all_optional_params.yaml
@@ -1,6 +1,61 @@
 interactions:
 - request:
-    body: '{"identity": {"type": "SystemAssigned"}, "tags": {"test": "value"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apic update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --tags --identity
+      User-Agent:
+      - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{},"systemData":{"createdAt":"2024-06-24T07:41:17.2805444Z","lastModifiedAt":"2024-06-24T07:41:17.280535Z"}}'
+    headers:
+      api-supported-versions:
+      - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '374'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 24 Jun 2024 07:41:20 GMT
+      etag:
+      - 1a0000aa-0000-0100-0000-6679231d0000
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: B83AEB98C6DD44B9B3E5394810480682 Ref B: MAA201060513051 Ref C: 2024-06-24T07:41:19Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "SystemAssigned"}, "location": "eastus", "properties":
+      {}, "sku": {"name": "Free"}, "tags": {"test": "value"}}'
     headers:
       Accept:
       - application/json
@@ -11,31 +66,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '67'
+      - '132'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --tags --identity
       User-Agent:
       - AZURECLI/2.58.0 azsdk-python-core/1.28.0 Python/3.11.9 (Windows-10-10.0.19045-SP0)
-    method: PATCH
+    method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002?api-version=2024-03-01
   response:
     body:
-      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","identity":{"type":"SystemAssigned","principalId":"0df94dc1-dacd-426d-b159-c1d4254ebcb2","tenantId":"f0348563-e707-449c-8685-c83d24eaf3c0"},"sku":{"name":"Free"},"properties":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{"test":"value"},"systemData":{"createdAt":"2024-06-17T06:13:14.6700682Z","lastModifiedAt":"2024-06-17T06:13:22.1933592Z"}}'
+      string: '{"type":"Microsoft.ApiCenter/services","location":"eastus","identity":{"type":"SystemAssigned","principalId":"994e5256-bca5-4bb4-8baf-45094cc2c011","tenantId":"f0348563-e707-449c-8685-c83d24eaf3c0"},"sku":{"name":"Free"},"properties":{"dataApiHostname":"clitest000002.data.eastus.azure-apicenter.ms"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clirg000001/providers/Microsoft.ApiCenter/services/clitest000002","name":"clitest000002","tags":{"test":"value"},"systemData":{"createdAt":"2024-06-24T07:41:17.2805444Z","lastModifiedAt":"2024-06-24T07:41:26.9585745Z"}}'
     headers:
       api-supported-versions:
       - 2023-07-01-preview, 2024-03-01, 2024-03-15-preview
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Jun 2024 06:13:23 GMT
-      etag:
-      - bb015d77-0000-0100-0000-666fd4020000
+      - Mon, 24 Jun 2024 07:41:29 GMT
       expires:
       - '-1'
       pragma:
@@ -53,7 +106,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '199'
       x-msedge-ref:
-      - 'Ref A: FCF1970463CF464E91A02E765BE544E4 Ref B: MAA201060516009 Ref C: 2024-06-17T06:13:16Z'
+      - 'Ref A: 3FC4D40800C4486AAC30325E943B8F6D Ref B: MAA201060513051 Ref C: 2024-06-24T07:41:20Z'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_service_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_service_commands.py
@@ -20,7 +20,25 @@ class ServiceCommandsTests(ScenarioTest):
         })
         self.cmd('az apic create -g {rg} --name {name}', checks=[
             self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}')
+            self.check('resourceGroup', '{rg}'),
+            self.check('sku.name', 'Free')
+        ])
+
+    @ResourceGroupPreparer(name_prefix="clirg", location=TEST_REGION, random_name_length=32)
+    def test_create_service_multiple_times(self, resource_group):
+        self.kwargs.update({
+          'name': self.create_random_name(prefix='cli', length=24),
+          'rg': resource_group
+        })
+        self.cmd('az apic create -g {rg} --name {name}', checks=[
+            self.check('name', '{name}'),
+            self.check('resourceGroup', '{rg}'),
+            self.check('sku.name', 'Free')
+        ])
+        self.cmd('az apic create -g {rg} --name {name}', checks=[
+            self.check('name', '{name}'),
+            self.check('resourceGroup', '{rg}'),
+            self.check('sku.name', 'Free')
         ])
     
     @ResourceGroupPreparer(name_prefix="clirg", location=TEST_REGION, random_name_length=32)
@@ -34,7 +52,8 @@ class ServiceCommandsTests(ScenarioTest):
             self.check('resourceGroup', '{rg}'),
             self.check('identity.type', 'SystemAssigned'),
             self.check('location', 'westeurope'),
-            self.check('tags.test', 'value')
+            self.check('tags.test', 'value'),
+            self.check('sku.name', 'Free')
         ])
 
     @ResourceGroupPreparer(name_prefix="clirg", location=TEST_REGION, random_name_length=32)
@@ -45,7 +64,8 @@ class ServiceCommandsTests(ScenarioTest):
         self.cmd('az apic show -g {rg} -n {s}', checks=[
             self.check('name', '{s}'),
             self.check('resourceGroup', '{rg}'),
-            self.check('dataApiHostname', '{s}.data.eastus.azure-apicenter.ms')
+            self.check('dataApiHostname', '{s}.data.eastus.azure-apicenter.ms'),
+            self.check('sku.name', 'Free')
         ])
 
     @unittest.skip('The Control Plane API has bug')
@@ -64,7 +84,8 @@ class ServiceCommandsTests(ScenarioTest):
     def test_list_service_in_rg(self, service_name):
         self.cmd('az apic list -g {rg}', checks=[
             self.check('length(@)', 1),
-            self.check('@[0].name', service_name)
+            self.check('@[0].name', service_name),
+            self.check('@[0].sku.name', 'Free')
         ])
 
     @ResourceGroupPreparer(name_prefix="clirg", location=TEST_REGION, random_name_length=32)


### PR DESCRIPTION
1. Fix error when run create command against existing resource. Run create command against existing resource is usually used in CICD scenario.
2.  Change `az apic update` command back to PUT request as we have SKU support in http client now

The SKU parameter is hided temporary because there're too many SKU properties, we need further discussion on how SKU should be supported in CLI.

https://msazure.visualstudio.com/One/_workitems/edit/28011732
https://msazure.visualstudio.com/One/_workitems/edit/27863921